### PR TITLE
Unify formatter and parseableFormatStyle/Formatter

### DIFF
--- a/SUITextFieldExample/SUITextFieldExample/ContentView.swift
+++ b/SUITextFieldExample/SUITextFieldExample/ContentView.swift
@@ -87,6 +87,7 @@ struct ContentView: View {
                         SUITextField(
                             value: $myDouble,
                             format: .number,
+                            formatPolicy: .onChange,
                             placeholder: AttributedString("Hey there")
                                 .mergingAttributes(AttributeContainer(placeholderAttributes))
                         )

--- a/Sources/SwiftUITextField/SwiftUITextField.docc/SUITextField.md
+++ b/Sources/SwiftUITextField/SwiftUITextField.docc/SUITextField.md
@@ -2,6 +2,25 @@
 
 ## Topics
 
+### Creating a text field with a string
+
+- ``SUITextField/init(text:placeholder:)-5btu0``
+- ``SUITextField/init(text:placeholder:)-7334w``
+- ``SUITextField/init(text:placeholder:)-9p6by``
+
+### Creating a text field with a value (iOS 15)
+
+- ``SUITextField/init(value:format:formatPolicy:placeholder:defaultValue:)-3i36v``
+- ``SUITextField/init(value:format:formatPolicy:placeholder:defaultValue:)-5fdb3``
+- ``SUITextField/init(value:format:formatPolicy:placeholder:)-9l23l``
+- ``SUITextField/init(value:format:formatPolicy:placeholder:)-2bhgs``
+- ``FormatPolicy``
+
+### Creating a text field with a value (pre-iOS 15)
+
+- ``SUITextField/init(value:formatter:formatPolicy:placeholder:defaultValue:)-3wopi``
+- ``SUITextField/init(value:formatter:formatPolicy:placeholder:defaultValue:)-1cub1``
+
 ### Modify style and behaviors
 
 - <doc:EnvironmentModifiers>

--- a/Sources/SwiftUITextField/SwiftUITextField.docc/SwiftUITextField.md
+++ b/Sources/SwiftUITextField/SwiftUITextField.docc/SwiftUITextField.md
@@ -84,7 +84,6 @@ formatters. Check all the provided initializers in ``SUITextField``!
 - ``ResponderState``
 - ``ResponderChainCoordinator``
 
-
 ### Miscellaneous 
 
 - ``CharacterReplacement``

--- a/Sources/SwiftUITextField/TextField/FormatPolicy.swift
+++ b/Sources/SwiftUITextField/TextField/FormatPolicy.swift
@@ -9,10 +9,6 @@ import Foundation
 
 /// Indicates when the bound value is updated on a ``SUITextField`` with format/formatter.
 ///
-/// When using ``SUITextField/init(value:format:formatPolicy:placeholder:)`` or
-/// ``SUITextField/init(value:formatter:formatPolicy:placeholder:defaultValue:)``
-/// the bound value is updated after the format/formatter parses it.
-///
 /// Policy can specify when the conversion is made, either during typing or when text field did end editing.
 public enum FormatPolicy {
     

--- a/Sources/SwiftUITextField/TextField/FormatPolicy.swift
+++ b/Sources/SwiftUITextField/TextField/FormatPolicy.swift
@@ -1,0 +1,24 @@
+//
+//  FormatPolicy.swift
+//  
+//
+//  Created by Rico Crescenzio on 15/04/22.
+//
+
+import Foundation
+
+/// Indicates when the bound value is updated on a ``SUITextField`` with format/formatter.
+///
+/// When using ``SUITextField/init(value:format:formatPolicy:placeholder:)`` or
+/// ``SUITextField/init(value:formatter:formatPolicy:placeholder:defaultValue:)``
+/// the bound value is updated after the format/formatter parses it.
+///
+/// Policy can specify when the conversion is made, either during typing or when text field did end editing.
+public enum FormatPolicy {
+    
+    /// Parses the text to bound value on every text insertion.
+    case onChange
+    
+    /// Parses the text to bound value when text field end editing.
+    case onCommit
+}


### PR DESCRIPTION
### 📎 References

- **Issue:** [2 - Unify formatter and parseableFormatStyle/Formatter](https://github.com/ricocrescenzio95/SUITextField/issues/2)

### 🔬 Implementation details

Initializers have now an additional parameter `FormatPolicy` which tells the text field how to parse the incoming text
to the value.

This is an `enum` with 2 cases:
- `onCommit`: tells the formatter to parse when text field end editing. This is the default behavior, which matches the `SwiftUI.TextField` one
- `onChange`: tells the formatter to parse on each text change.

Internal implementation of `init` now checks the given `formatPolicy` and modify the `binding` to modify value in its `set` only for `onChange` behavior.
When `onCommit` is passed, the `binding` doesn't do anything and a private `_onEndEditingAction` is used to parse and set the value when `textFieldDidEndEditing` delegate is called.

### ✅ Checks

<!-- Feel free to delete next lines if PR doesn't involve them -->

- [x] **Documentation:** Update both doc comments and `DocC`.
