### PR TITLE
Made ResponderModifier available from any View

### DIFF
--- a/Sources/SwiftUITextField/Responder/ResponderChainCoordinator.swift
+++ b/Sources/SwiftUITextField/Responder/ResponderChainCoordinator.swift
@@ -93,7 +93,7 @@ public class ResponderChainCoordinator: NSObject {
                 })
         } else if let responderStorage = context.environment.responderStorage as? AnyHashableResponderStorage {
             cancellable = responderStorage.$value
-                .compactMap { $0 as? Hashable }
+                .compactMap { $0 as? (any Hashable) }
                 .sink(receiveValue: { selectedValue in
                     applyResponder(value.hashValue == selectedValue.hashValue)
                 })

--- a/Sources/SwiftUITextField/Responder/ResponderModifier.swift
+++ b/Sources/SwiftUITextField/Responder/ResponderModifier.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public extension SUITextField {
+public extension View {
 
     /// Modifies this view by binding its responder state to the given state value.
     ///


### PR DESCRIPTION
### 📎 References

- **Issue:** [Set responder state from parent](https://github.com/ricocrescenzio95/SUITextField/issues/8)

### 🔬 Implementation details

Made `responder<Value>(_ binding: ResponderState<Value>.Binding, equals value: Value)` and `responder(_ binding: ResponderState<Bool>.Binding)` available in any view instead of just SUITextField.

### :art: Screenshots or videos


### 🩺 How can it be tested?


### ✅ Checks
